### PR TITLE
Critical bug fix for website connections

### DIFF
--- a/edenbotcogs/coghelpers/Market_helper.py
+++ b/edenbotcogs/coghelpers/Market_helper.py
@@ -99,9 +99,9 @@ def check_prefixes(item_stub):
 
 
 async def check_stack_flag(item_name):
-    check_url = f'http://www.classicffxi.com/api/v1/items/{item_name}'
+    check_url = f'https://144.217.79.186/api/v1/items/{item_name}'
     async with aiohttp.ClientSession() as s:
-        async with s.get(check_url) as resp:
+        async with s.get(check_url, ssl=False) as resp:
             check_page = await resp.text()
     is_stack = check_page.split(',')[1][11:]
     return is_stack
@@ -133,10 +133,10 @@ async def build_AH_embed(item_name, stack_flag, server_id):
 
     embed_title = format_name(item_name)
 
-    url = f'http://www.classicffxi.com/api/v1/items/{item_name}/ah?stack={stack_flag}'
+    url = f'https://144.217.79.186/api/v1/items/{item_name}/ah?stack={stack_flag}'
 
     async with aiohttp.ClientSession() as s:
-        async with s.get(url) as resp:
+        async with s.get(url, ssl=False) as resp:
             ah_info = await resp.text()
 
     if ah_info == '[]':
@@ -159,9 +159,9 @@ async def build_AH_embed(item_name, stack_flag, server_id):
 async def build_bazaar_embed(item_name):
     embed_title = format_name(item_name)
 
-    url = f'http://www.classicffxi.com/api/v1/items/{item_name}/bazaar'
+    url = f'https://144.217.79.186/api/v1/items/{item_name}/bazaar'
     async with aiohttp.ClientSession() as s:
-        async with s.get(url) as resp:
+        async with s.get(url, ssl=False) as resp:
             ah_info = await resp.text()
 
     ah_info = ast.literal_eval(ah_info)

--- a/edenbotcogs/coghelpers/Player_helper.py
+++ b/edenbotcogs/coghelpers/Player_helper.py
@@ -16,7 +16,7 @@ import aiohttp
 from random import randint
 
 
-char_url = 'http://classicffxi.com/api/v1/chars/'
+char_url = 'https://144.217.79.186/api/v1/chars/'
 avatars = dict(ef1a='https://vignette.wikia.nocookie.net/ffxi/images/d/d7/Ef1a.jpg',
                ef2a='https://vignette.wikia.nocookie.net/ffxi/images/c/c1/Ef2a.jpg',
                ef3a='https://vignette.wikia.nocookie.net/ffxi/images/a/a4/Ef3a.jpg',
@@ -146,7 +146,7 @@ avatars = dict(ef1a='https://vignette.wikia.nocookie.net/ffxi/images/d/d7/Ef1a.j
                tm2a='https://vignette.wikia.nocookie.net/ffxi/images/f/f0/Tm2a.jpg',
                tm1a='https://vignette.wikia.nocookie.net/ffxi/images/d/d8/Tm1a.jpg')
 base_url = 'https://static.ffxiah.com/images/icon/'
-base_ah_url = 'http://www.classicffxi.com/tools/item/'
+base_ah_url = 'https://www.144.217.79.186/tools/item/'
 equip_background = 'https://www.ffxiah.com/images/equip_box.gif'
 
 
@@ -161,7 +161,7 @@ def format_name(name):
 async def check_player_exist(player):
     url = char_url + player
     async with aiohttp.ClientSession() as s:
-        async with s.get(url) as resp:
+        async with s.get(url, ssl=False) as resp:
             player_data = await resp.text()
     if player_data:
         return True
@@ -171,7 +171,7 @@ async def check_player_exist(player):
 async def get_player_info(player):
     url = char_url + player
     async with aiohttp.ClientSession() as s:
-        async with s.get(url) as resp:
+        async with s.get(url, ssl=False) as resp:
             p_info = await resp.text()
     p_info = ast.literal_eval(p_info)
     return p_info
@@ -193,7 +193,7 @@ def get_avatar_img(avatar_id):
 async def get_player_crafts(player):
     url = char_url + player + '/crafts'
     async with aiohttp.ClientSession() as s:
-        async with s.get(url) as resp:
+        async with s.get(url, ssl=False) as resp:
             craft_info = await resp.text()
     craft_info = ast.literal_eval(craft_info)
     return craft_info
@@ -202,7 +202,7 @@ async def get_player_crafts(player):
 async def get_player_jobs(player):
     url = char_url + player
     async with aiohttp.ClientSession() as s:
-        async with s.get(url) as resp:
+        async with s.get(url, ssl=False) as resp:
             p_info = await resp.text()
     p_info = ast.literal_eval(p_info)
     return p_info['jobs']
@@ -211,7 +211,7 @@ async def get_player_jobs(player):
 async def get_player_equip(player):
     url = char_url + player + '/equip'
     async with aiohttp.ClientSession() as s:
-        async with s.get(url) as resp:
+        async with s.get(url, ssl=False) as resp:
             equip_info = await resp.text()
     equip_info = ast.literal_eval(equip_info)
     return equip_info
@@ -244,7 +244,7 @@ async def build_equip_visual(ordered_ids):
             imgs.append(0)
         url = base_url + str(equip_id) + '.png'
         async with aiohttp.ClientSession() as s:
-            async with s.get(url) as resp:
+            async with s.get(url, ssl=False) as resp:
                 img_bytes = await resp.read()
         img_bytes = BytesIO(img_bytes)
         imgs.append(Image.open(img_bytes))

--- a/edenbotcogs/coghelpers/yellbot_helper.py
+++ b/edenbotcogs/coghelpers/yellbot_helper.py
@@ -9,12 +9,12 @@ import re
 import aiohttp
 from edenbotcogs.coghelpers.Timers_helper import get_timezone, server_timezones
 
-yell_url = 'http://classicffxi.com/api/v1/misc/yells'
+yell_url = 'https://144.217.79.186/api/v1/misc/yells'
 
 
 async def get_new_yells(yell_history):
     async with aiohttp.ClientSession() as s:
-        async with s.get(yell_url) as resp:
+        async with s.get(yell_url, ssl=False) as resp:
             yell_info = await resp.text()
 
     yell_info = ast.literal_eval(yell_info)
@@ -106,7 +106,7 @@ async def check_connection(url):
     valid_connection = False
     try:
         async with aiohttp.ClientSession() as s:
-            async with s.get(url) as resp:
+            async with s.get(url, ssl=False) as resp:
                 if resp.status == 200:
                     valid_connection = True
     except Exception:

--- a/edenbotcogs/cogs/Player.py
+++ b/edenbotcogs/cogs/Player.py
@@ -79,7 +79,7 @@ class Player(commands.Cog):
             activity_dict = {}
 
         async with aiohttp.ClientSession() as s:
-            async with s.get('http://www.classicffxi.com/api/v1/chars?online=true&limit=28000') as resp:
+            async with s.get('https://144.217.79.186/api/v1/chars?online=true&limit=28000') as resp:
                 current_online = await resp.text()
         current_online = ast.literal_eval(current_online)['chars']
         log_time = int(time())

--- a/edenbotcogs/cogs/Player.py
+++ b/edenbotcogs/cogs/Player.py
@@ -79,7 +79,7 @@ class Player(commands.Cog):
             activity_dict = {}
 
         async with aiohttp.ClientSession() as s:
-            async with s.get('https://144.217.79.186/api/v1/chars?online=true&limit=28000') as resp:
+            async with s.get('https://144.217.79.186/api/v1/chars?online=true&limit=28000', ssl=False) as resp:
                 current_online = await resp.text()
         current_online = ast.literal_eval(current_online)['chars']
         log_time = int(time())


### PR DESCRIPTION
Changed the url used to connect to Eden's website from classicffxi.com (no longer in use) to the IP address for the website. While the current url (edenxi.com) would have been preferred, I couldn't find a way to get it to work with aiohttp.
Fixes #39 